### PR TITLE
On demand refresh support

### DIFF
--- a/internal/controller/appconfigurationprovider_controller.go
+++ b/internal/controller/appconfigurationprovider_controller.go
@@ -391,16 +391,17 @@ func (reconciler *AzureAppConfigurationProviderReconciler) createOrUpdateConfigM
 		return reconcile.Result{Requeue: true, RequeueAfter: RequeueReconcileAfter}, err
 	}
 
-	annotations := map[string]string{
-		LastReconcileTimeAnnotation: metav1.Now().UTC().String(),
+	if provider.Annotations == nil {
+		provider.Annotations = make(map[string]string)
 	}
+	provider.Annotations[LastReconcileTimeAnnotation] = metav1.Now().UTC().String()
 	if len(settings.ConfigMapSettings) == 0 {
 		klog.V(3).Info("No configMap settings are fetched from Azure AppConfiguration")
 	}
 	operationResult, err := ctrl.CreateOrUpdate(ctx, reconciler.Client, configMapObj, func() error {
 		configMapObj.Data = settings.ConfigMapSettings
 		configMapObj.Labels = provider.Labels
-		configMapObj.Annotations = annotations
+		configMapObj.Annotations = provider.Annotations
 
 		return nil
 	})
@@ -456,13 +457,14 @@ func (reconciler *AzureAppConfigurationProviderReconciler) createOrUpdateSecrets
 			return reconcile.Result{Requeue: true, RequeueAfter: RequeueReconcileAfter}, err
 		}
 
-		annotations := map[string]string{
-			LastReconcileTimeAnnotation: metav1.Now().UTC().String(),
+		if provider.Annotations == nil {
+			provider.Annotations = make(map[string]string)
 		}
+		provider.Annotations[LastReconcileTimeAnnotation] = metav1.Now().UTC().String()
 		operationResult, err := ctrl.CreateOrUpdate(ctx, reconciler.Client, secretObj, func() error {
 			secretObj.Data = secret.Data
 			secretObj.Labels = provider.Labels
-			secretObj.Annotations = annotations
+			secretObj.Annotations = provider.Annotations
 
 			return nil
 		})


### PR DESCRIPTION
User can modify `metadata.annotations` section to have a on-demand refresh.