### PR TITLE
Audience parameter support

### DIFF
--- a/deploy/parameter/helm-values.yaml
+++ b/deploy/parameter/helm-values.yaml
@@ -67,6 +67,8 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   targetMemoryUtilizationPercentage: 80
 
+audience: ""
+
 env:
   azureClientId: ""
   azureTenantId: ""

--- a/deploy/parameter/helm-values.yaml
+++ b/deploy/parameter/helm-values.yaml
@@ -67,11 +67,10 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   targetMemoryUtilizationPercentage: 80
 
-audience: ""
-
 env:
   azureClientId: ""
   azureTenantId: ""
+  azureAppConfigurationAudience: ""
 
 # Pod scheduling preferences
 # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity

--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -88,6 +88,10 @@ spec:
         {{- end }}
         - name: REQUEST_TRACING_ENABLED
           value: "{{ .Values.requestTracing.enabled }}"
+        {{- if .Values.audience }}
+        - name: AZURE_APPCONFIG_AUDIENCE
+          value: {{ .Values.audience | quote }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -88,9 +88,9 @@ spec:
         {{- end }}
         - name: REQUEST_TRACING_ENABLED
           value: "{{ .Values.requestTracing.enabled }}"
-        {{- if .Values.audience }}
+        {{- if .Values.env.azureAppConfigurationAudience }}
         - name: AZURE_APPCONFIG_AUDIENCE
-          value: {{ .Values.audience | quote }}
+          value: {{ .Values.env.azureAppConfigurationAudience | quote }}
         {{- end }}
         livenessProbe:
           httpGet:

--- a/internal/loader/configuration_client_manager.go
+++ b/internal/loader/configuration_client_manager.go
@@ -19,6 +19,7 @@ import (
 	acpv1 "azappconfig/provider/api/v1"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	azappconfig "github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig/v2"
@@ -80,17 +81,30 @@ const (
 	ApiTokenExchangeAudience            string        = "api://AzureADTokenExchange"
 	AnnotationClientID                  string        = "azure.workload.identity/client-id"
 	AnnotationTenantID                  string        = "azure.workload.identity/tenant-id"
+	AzureAppConfigAudience              string        = "AZURE_APPCONFIG_AUDIENCE"
 )
 
-var (
-	clientOptionWithModuleInfo *azappconfig.ClientOptions = &azappconfig.ClientOptions{
+func newClientOptions() *azappconfig.ClientOptions {
+	options := &azappconfig.ClientOptions{
 		ClientOptions: policy.ClientOptions{
 			Telemetry: policy.TelemetryOptions{
 				ApplicationID: fmt.Sprintf("%s/%s", properties.ModuleName, properties.ModuleVersion),
 			},
 		},
 	}
-)
+
+	if audience, ok := os.LookupEnv(AzureAppConfigAudience); ok && audience != "" {
+		options.ClientOptions.Cloud = cloud.Configuration{
+			Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+				azappconfig.ServiceName: {
+					Audience: audience,
+				},
+			},
+		}
+	}
+
+	return options
+}
 
 func NewConfigurationClientManager(ctx context.Context, provider acpv1.AzureAppConfigurationProvider) (ClientManager, error) {
 	manager := &ConfigurationClientManager{
@@ -118,14 +132,14 @@ func NewConfigurationClientManager(ctx context.Context, provider acpv1.AzureAppC
 		if manager.id, err = parseConnectionString(connectionString, IdSection); err != nil {
 			return nil, err
 		}
-		if staticClient, err = azappconfig.NewClientFromConnectionString(connectionString, clientOptionWithModuleInfo); err != nil {
+		if staticClient, err = azappconfig.NewClientFromConnectionString(connectionString, newClientOptions()); err != nil {
 			return nil, err
 		}
 	} else {
 		if manager.credential, err = CreateTokenCredential(ctx, provider.Spec.Auth, provider.Namespace); err != nil {
 			return nil, err
 		}
-		if staticClient, err = azappconfig.NewClient(*provider.Spec.Endpoint, manager.credential, clientOptionWithModuleInfo); err != nil {
+		if staticClient, err = azappconfig.NewClient(*provider.Spec.Endpoint, manager.credential, newClientOptions()); err != nil {
 			return nil, err
 		}
 		manager.endpoint = *provider.Spec.Endpoint
@@ -286,7 +300,7 @@ func QuerySrvTargetHost(ctx context.Context, host string) ([]string, error) {
 
 func (manager *ConfigurationClientManager) newConfigurationClient(endpoint string) (*azappconfig.Client, error) {
 	if manager.credential != nil {
-		return azappconfig.NewClient(endpoint, manager.credential, clientOptionWithModuleInfo)
+		return azappconfig.NewClient(endpoint, manager.credential, newClientOptions())
 	}
 
 	connectionStr := buildConnectionString(endpoint, manager.secret, manager.id)
@@ -294,7 +308,7 @@ func (manager *ConfigurationClientManager) newConfigurationClient(endpoint strin
 		return nil, fmt.Errorf("failed to build connection string for fallback client")
 	}
 
-	return azappconfig.NewClientFromConnectionString(connectionStr, clientOptionWithModuleInfo)
+	return azappconfig.NewClientFromConnectionString(connectionStr, newClientOptions())
 }
 
 func isValidEndpoint(host string, validDomain string) bool {

--- a/internal/loader/configuration_client_manager.go
+++ b/internal/loader/configuration_client_manager.go
@@ -81,7 +81,7 @@ const (
 	ApiTokenExchangeAudience            string        = "api://AzureADTokenExchange"
 	AnnotationClientID                  string        = "azure.workload.identity/client-id"
 	AnnotationTenantID                  string        = "azure.workload.identity/tenant-id"
-	AzureAppConfigAudience              string        = "AZURE_APPCONFIG_AUDIENCE"
+	AzureAppConfigurationAudience       string        = "AZURE_APPCONFIGURATION_AUDIENCE"
 )
 
 func newClientOptions() *azappconfig.ClientOptions {
@@ -93,7 +93,7 @@ func newClientOptions() *azappconfig.ClientOptions {
 		},
 	}
 
-	if audience, ok := os.LookupEnv(AzureAppConfigAudience); ok && audience != "" {
+	if audience, ok := os.LookupEnv(AzureAppConfigurationAudience); ok && audience != "" {
 		options.ClientOptions.Cloud = cloud.Configuration{
 			Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
 				azappconfig.ServiceName: {

--- a/internal/loader/configuration_client_manager_test.go
+++ b/internal/loader/configuration_client_manager_test.go
@@ -64,7 +64,9 @@ func TestNewClientOptions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Clean up the env var before each test
-			os.Unsetenv(AzureAppConfigAudience)
+			if err := os.Unsetenv(AzureAppConfigAudience); err != nil {
+				t.Fatalf("Failed to unset environment variable: %v", err)
+			}
 
 			// Setup environment variables
 			if tt.envVars != nil {

--- a/internal/loader/configuration_client_manager_test.go
+++ b/internal/loader/configuration_client_manager_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package loader
+
+import (
+	"azappconfig/provider/internal/properties"
+	"fmt"
+	"os"
+	"testing"
+
+	azappconfig "github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig/v2"
+)
+
+func TestNewClientOptions(t *testing.T) {
+	expectedAppID := fmt.Sprintf("%s/%s", properties.ModuleName, properties.ModuleVersion)
+
+	tests := []struct {
+		name             string
+		envVars          map[string]string
+		expectedAudience string
+		hasCloudConfig   bool
+	}{
+		{
+			name:             "no audience set - default behavior",
+			envVars:          nil,
+			expectedAudience: "",
+			hasCloudConfig:   false,
+		},
+		{
+			name: "audience set to Azure Government",
+			envVars: map[string]string{
+				AzureAppConfigAudience: "https://appconfig.azure.us",
+			},
+			expectedAudience: "https://appconfig.azure.us",
+			hasCloudConfig:   true,
+		},
+		{
+			name: "audience set to Azure China",
+			envVars: map[string]string{
+				AzureAppConfigAudience: "https://appconfig.azure.cn",
+			},
+			expectedAudience: "https://appconfig.azure.cn",
+			hasCloudConfig:   true,
+		},
+		{
+			name: "audience set to empty string",
+			envVars: map[string]string{
+				AzureAppConfigAudience: "",
+			},
+			expectedAudience: "",
+			hasCloudConfig:   false,
+		},
+		{
+			name: "audience set to custom value",
+			envVars: map[string]string{
+				AzureAppConfigAudience: "https://custom.audience.example",
+			},
+			expectedAudience: "https://custom.audience.example",
+			hasCloudConfig:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clean up the env var before each test
+			os.Unsetenv(AzureAppConfigAudience)
+
+			// Setup environment variables
+			if tt.envVars != nil {
+				for k, v := range tt.envVars {
+					if err := os.Setenv(k, v); err != nil {
+						t.Fatalf("Failed to set environment variable: %v", err)
+					}
+					defer func(key string) {
+						if err := os.Unsetenv(key); err != nil {
+							t.Errorf("Failed to unset environment variable: %v", err)
+						}
+					}(k)
+				}
+			}
+
+			options := newClientOptions()
+
+			// Verify telemetry ApplicationID is always set
+			if options.ClientOptions.Telemetry.ApplicationID != expectedAppID {
+				t.Errorf("Expected ApplicationID %q, got %q", expectedAppID, options.ClientOptions.Telemetry.ApplicationID)
+			}
+
+			// Verify cloud configuration / audience
+			if tt.hasCloudConfig {
+				serviceConfig, exists := options.ClientOptions.Cloud.Services[azappconfig.ServiceName]
+				if !exists {
+					t.Fatal("Expected cloud service configuration to be set for azappconfig.ServiceName, but it was not found")
+				}
+				if serviceConfig.Audience != tt.expectedAudience {
+					t.Errorf("Expected audience %q, got %q", tt.expectedAudience, serviceConfig.Audience)
+				}
+			} else {
+				if len(options.ClientOptions.Cloud.Services) != 0 {
+					t.Errorf("Expected no cloud service configuration, but got %v", options.ClientOptions.Cloud.Services)
+				}
+			}
+		})
+	}
+}

--- a/internal/loader/configuration_client_manager_test.go
+++ b/internal/loader/configuration_client_manager_test.go
@@ -30,7 +30,7 @@ func TestNewClientOptions(t *testing.T) {
 		{
 			name: "audience set to Azure Government",
 			envVars: map[string]string{
-				AzureAppConfigAudience: "https://appconfig.azure.us",
+				AzureAppConfigurationAudience: "https://appconfig.azure.us",
 			},
 			expectedAudience: "https://appconfig.azure.us",
 			hasCloudConfig:   true,
@@ -38,7 +38,7 @@ func TestNewClientOptions(t *testing.T) {
 		{
 			name: "audience set to Azure China",
 			envVars: map[string]string{
-				AzureAppConfigAudience: "https://appconfig.azure.cn",
+				AzureAppConfigurationAudience: "https://appconfig.azure.cn",
 			},
 			expectedAudience: "https://appconfig.azure.cn",
 			hasCloudConfig:   true,
@@ -46,7 +46,7 @@ func TestNewClientOptions(t *testing.T) {
 		{
 			name: "audience set to empty string",
 			envVars: map[string]string{
-				AzureAppConfigAudience: "",
+				AzureAppConfigurationAudience: "",
 			},
 			expectedAudience: "",
 			hasCloudConfig:   false,
@@ -54,7 +54,7 @@ func TestNewClientOptions(t *testing.T) {
 		{
 			name: "audience set to custom value",
 			envVars: map[string]string{
-				AzureAppConfigAudience: "https://custom.audience.example",
+				AzureAppConfigurationAudience: "https://custom.audience.example",
 			},
 			expectedAudience: "https://custom.audience.example",
 			hasCloudConfig:   true,
@@ -64,7 +64,7 @@ func TestNewClientOptions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Clean up the env var before each test
-			if err := os.Unsetenv(AzureAppConfigAudience); err != nil {
+			if err := os.Unsetenv(AzureAppConfigurationAudience); err != nil {
 				t.Fatalf("Failed to unset environment variable: %v", err)
 			}
 


### PR DESCRIPTION
Usage
```
helm install azureappconfiguration.kubernetesprovider \
    oci://mcr.microsoft.com/azure-app-configuration/helmchart/kubernetes-provider \
    --namespace azappconfig-system \
    --create-namespace
    --set env.azureAppConfigurationAudience="https://appconfig.sovcloud-api.fr"
```