### PR TITLE
Update base image to core 2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ARG TARGETARCH
 RUN CGO_ENABLED=1 GOOS=linux GOARCH=$TARGETARCH go build -ldflags "-X azappconfig/provider/internal/properties.ModuleVersion=$MODULE_VERSION" -a -o manager cmd/main.go
  
 # Use distroless as minimal base image to package the manager binary
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0-nonroot
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/cbl-mariner/base/core:2.0-nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532


### PR DESCRIPTION
Update base image to core 2.0

CGO_ENABLED=1 — This produced a dynamically-linked binary that depends on glibc/ld-linux from the builder image. The distroless runtime image doesn't have those shared libraries, so the dynamic linker is literally "not found."