### PR TITLE
Fix lint error

### DIFF
--- a/internal/controller/processor.go
+++ b/internal/controller/processor.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
@@ -254,7 +253,9 @@ func (processor *AppConfigurationProviderProcessor) processSecretReferenceRefres
 	for secretName, resolvedSecret := range resolvedSecrets.SecretSettings {
 		existingSecret, ok := secrets[secretName]
 		if ok {
-			maps.Copy(existingSecret.Data, resolvedSecret.Data)
+			for k, v := range resolvedSecret.Data {
+				existingSecret.Data[k] = v
+			}
 		}
 	}
 

--- a/internal/loader/configuration_setting_loader.go
+++ b/internal/loader/configuration_setting_loader.go
@@ -24,7 +24,6 @@ import (
 	azappconfig "github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig/v2"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
 	"golang.org/x/crypto/pkcs12"
-	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/syncmap"
 	corev1 "k8s.io/api/core/v1"
@@ -1061,7 +1060,11 @@ func MergeSecret(secret map[string]corev1.Secret, newSecret map[string]corev1.Se
 		} else if secret[k].Type != v.Type {
 			return fmt.Errorf("secret type mismatch for key %q", k)
 		} else {
-			maps.Copy(secret[k].Data, v.Data)
+			existing := secret[k]
+			for dk, dv := range v.Data {
+				existing.Data[dk] = dv
+			}
+			secret[k] = existing
 		}
 	}
 


### PR DESCRIPTION
Fix lint error https://github.com/Azure/AppConfiguration-KubernetesProvider/actions/runs/25718318125/job/75513191791?pr=176

```
  Error: internal/controller/processor.go:257:13: inline: cannot inline: type parameter inference is not yet supported (govet)
  			maps.Copy(existingSecret.Data, resolvedSecret.Data)
  			         ^
  Error: internal/loader/configuration_setting_loader.go:1064:13: inline: cannot inline: type parameter inference is not yet supported (govet)
  			maps.Copy(secret[k].Data, v.Data)
  			         ^
  2 issues:
  * govet: 2
  
  Error: issues found
```